### PR TITLE
support building the glsl compiler on macOS

### DIFF
--- a/cafecompiler/cafe_glsl_compiler.cpp
+++ b/cafecompiler/cafe_glsl_compiler.cpp
@@ -14,7 +14,9 @@
 
 // C headers
 #define __cplusplusTMP __cplusplus
+#ifdef __APPLE__
 #define _WCHAR_T wchar_t
+#endif
 #undef __cplusplus
 extern "C"
 {

--- a/cafecompiler/cafe_glsl_compiler.cpp
+++ b/cafecompiler/cafe_glsl_compiler.cpp
@@ -14,6 +14,7 @@
 
 // C headers
 #define __cplusplusTMP __cplusplus
+#define _WCHAR_T wchar_t
 #undef __cplusplus
 extern "C"
 {


### PR DESCRIPTION
currently the project could not be built on macOS even with all the dependencies installed due to our use of: `#undef __cplusplus`, some of the macOS system headers will try to re-define wchar_t. this results in an error like:

```
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_wchar_t.h:24:24: error: cannot combine with previous 'int' declaration specifier
   24 | typedef __WCHAR_TYPE__ wchar_t;
```

The simplest fix for this is to define `_WCHAR_T` which then doesn't trigger the typedef check. So that performs this, and the compiler is able to successfully build on macOS for both arm64 + intel architectures.

this does cause a compiler warning for Linux where we have redefined _WCHAR_T, but this seems to be okay as the previous definition only seems to be a bare define (with no value), so redefining it to a value shouldn't be an issue:

```
../cafecompiler/cafe_glsl_compiler.cpp:17: warning: "_WCHAR_T" redefined
   17 | #define _WCHAR_T wchar_t
      |
In file included from /usr/include/c++/13/bits/cxxabi_init_exception.h:38,
                 from /usr/include/c++/13/bits/exception_ptr.h:36,
                 from /usr/include/c++/13/exception:164,
                 from /usr/include/c++/13/mutex:41,
                 from ../cafecompiler/cafe_glsl_compiler.cpp:8:
/usr/lib/gcc/aarch64-linux-gnu/13/include/stddef.h:269: note: this is the location of the previous definition
  269 | #define _WCHAR_T
      |
```