### PR TITLE
Fully disable `lower_wpos_ytransform` pass

### DIFF
--- a/src/compiler/nir/nir_lower_wpos_ytransform.c
+++ b/src/compiler/nir/nir_lower_wpos_ytransform.c
@@ -80,9 +80,6 @@ emit_wpos_adjustment(lower_wpos_ytransform_state *state,
                      nir_intrinsic_instr *intr, bool invert,
                      float adjX, float adjY[2])
 {
-#if defined(__WUT__)
-    return; // avoid FragCoord transformation to prevent creation of gl_FbWposYTransform uniform var
-#endif
    nir_builder *b = &state->b;
    nir_ssa_def *wpostrans, *wpos_temp, *wpos_temp_y, *wpos_input;
 

--- a/src/mesa/state_tracker/st_glsl_to_nir.cpp
+++ b/src/mesa/state_tracker/st_glsl_to_nir.cpp
@@ -833,8 +833,9 @@ st_link_nir(struct gl_context *ctx,
       if (nir->info.stage == MESA_SHADER_VERTEX && !shader_program->data->spirv)
          nir_remap_dual_slot_attributes(nir, &shader->Program->DualSlotInputs);
 
-      NIR_PASS_V(nir, st_nir_lower_wpos_ytransform, shader->Program,
-                 st->screen);
+      // CafeGLSL edit: avoid transformations to prevent creation of gl_FbWposYTransform uniform var
+      // NIR_PASS_V(nir, st_nir_lower_wpos_ytransform, shader->Program,
+      //            st->screen);
 
       NIR_PASS_V(nir, nir_lower_system_values);
       NIR_PASS_V(nir, nir_lower_compute_system_values, NULL);


### PR DESCRIPTION
Avoids using the mesa internal `gl_FbWposYTransform` uniform as described by https://github.com/Exzap/CafeGLSL/commit/b4d130b0a2ee4155b382a13395ff435a6264845d for other adjustments like `dFdy`